### PR TITLE
fix: some installations not detecting Task version correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed some installations (e.g. Brew) not detecting the Task version correctly (#13, #14 by @pd93).
+
 ## v0.1.0 - 2023-03-26
 
 - View tasks in the sidebar.

--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -108,7 +108,7 @@ class TaskfileService {
 
     parseVersion(stdout: string): semver.SemVer | undefined {
         // Extract the version string from the output
-        let matches = stdout.match(/v(\d+\.\d+\.\d+)/);
+        let matches = stdout.match(/(\d+\.\d+\.\d+)/);
         if (!matches || matches.length !== 2) {
             return undefined;
         }


### PR DESCRIPTION
Fixes #13 by removing the `v` prefix from the regex as some installations strip it from the semver string