### PR TITLE
Task sorting in tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added the ability to sort tasks in the tree view.
+  - Configurable via `task.tree.sort` setting (values: `"default"` (default), `"alphanumeric"` or `"none"`).
+
 ## v0.1.1 - 2021-03-27
 
 - Fixed some installations (e.g. Brew) not detecting the Task version correctly (#13, #14 by @pd93).
@@ -17,7 +22,7 @@
 - Refresh on save.
   - Configurable via `task.updateOn` setting (values: `"save"` (default) or `"manual"`).
 - Toggle tree nesting on/off
-  - Configurable via `task.nesting` setting (values: `true` (default) or `false`).
+  - Configurable via `task.tree.nesting` setting (values: `true` (default) or `false`).
 - Change the path to the Task binary.
   - Can also be set to the name of a binary in your `$PATH`.
   - Configurable via `task.path` setting (defaults to `"task"`).

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@
 
 ## Configuration
 
-| Setting           | Type      | Allowed Values       | Default  | Description                                                             |
-| ----------------- | --------- | -------------------- | -------- | ----------------------------------------------------------------------- |
-| `updateOn`        | `string`  | `"manual"`, `"save"` | `"save"` | When the list of tasks should be updated.                               |
-| `path`            | `string`  |                      | `"task"` | Path to the Task binary. Can also the name of a binary in your `$PATH`. |
-| `checkForUpdates` | `boolean` |                      | `true`   | Check if there is a newer version of Task on startup.                   |
-| `tree.nesting`    | `boolean` |                      | `true`   | Whether to nest tasks by their namespace in the tree view.              |
+| Setting           | Type      | Allowed Values                    | Default     | Description                                                             |
+| ----------------- | --------- | --------------------------------- | ----------- | ----------------------------------------------------------------------- |
+| `updateOn`        | `string`  | `"manual"`, `"save"`              | `"save"`    | When the list of tasks should be updated.                               |
+| `path`            | `string`  |                                   | `"task"`    | Path to the Task binary. Can also the name of a binary in your `$PATH`. |
+| `checkForUpdates` | `boolean` |                                   | `true`      | Check if there is a newer version of Task on startup.                   |
+| `tree.nesting`    | `boolean` |                                   | `true`      | Whether to nest tasks by their namespace in the tree view.              |
+| `tree.sort`       | `sort`    | `default`, `alphanumeric`, `none` | `"default"` | The order in which to display tasks in the tree view.                   |

--- a/package.json
+++ b/package.json
@@ -260,6 +260,16 @@
                   "type": "boolean",
                   "default": true,
                   "description": "Whether to nest tasks by their namespace in the tree view."
+                },
+                "sort": {
+                  "type": "string",
+                  "enum": [
+                    "default",
+                    "alphanumeric",
+                    "none"
+                  ],
+                  "default": "default",
+                  "description": "The order in which to display tasks in the tree view."
                 }
               }
             }

--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -150,7 +150,7 @@ class TaskfileService {
     public async read(dir: string): Promise<models.Taskfile> {
         log.info(`Searching for taskfile in: "${dir}"`);
         return await new Promise((resolve, reject) => {
-            let command = this.command('--list-all --json');
+            let command = this.command(`--list-all --json --sort ${settings.treeSort}`);
             cp.exec(command, { cwd: dir }, (err: cp.ExecException | null, stdout: string) => {
                 if (err) {
                     log.error(err);

--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -13,12 +13,14 @@ type ReleaseRequest = Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["pa
 type ReleaseResponse = Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["response"];
 
 const minimumRequiredVersion = '3.23.0';
+const minimumRequiredVersionForSorting = '3.24.0';
 
 class TaskfileService {
     private static _instance: TaskfileService;
     private static outputChannel: vscode.OutputChannel;
     private lastTaskName: string | undefined;
     private lastTaskDir: string | undefined;
+    private version: semver.SemVer | undefined;
 
     private constructor() {
         TaskfileService.outputChannel = vscode.window.createOutputChannel('Task');
@@ -46,23 +48,24 @@ class TaskfileService {
                 // If the version is a devel version, ignore all version checks
                 if (stdout.includes("devel")) {
                     log.info("Using development version of task");
+                    this.version = new semver.SemVer("999.0.0");
                     return resolve("ready");
                 }
 
                 // Get the installed version of task (if any)
-                let version = this.parseVersion(stdout);
+                this.version = this.parseVersion(stdout);
 
                 // If there is an error fetching the version, assume task is not installed
-                if (stderr !== "" || version === undefined) {
-                    log.error(version ? stderr : "Version is undefined");
+                if (stderr !== "" || this.version === undefined) {
+                    log.error(this.version ? stderr : "Version is undefined");
                     vscode.window.showErrorMessage("Task command not found.", "Install").then(this.buttonCallback);
                     return resolve("notInstalled");
                 }
 
                 // If the current version is older than the minimum required version, show an error
-                if (version && version.compare(minimumRequiredVersion) < 0) {
-                    log.error(`Task v${minimumRequiredVersion} is required to run this extension. The current version is v${version}`);
-                    vscode.window.showErrorMessage(`Task v${minimumRequiredVersion} is required to run this extension. The current version is v${version}.`, "Update").then(this.buttonCallback);
+                if (this.version && this.version.compare(minimumRequiredVersion) < 0) {
+                    log.error(`Task v${minimumRequiredVersion} is required to run this extension. The current version is v${this.version}`);
+                    vscode.window.showErrorMessage(`Task v${minimumRequiredVersion} is required to run this extension. The current version is v${this.version}.`, "Update").then(this.buttonCallback);
                     return resolve("outOfDate");
                 }
 
@@ -70,9 +73,9 @@ class TaskfileService {
                 // TODO: what happens if the user is offline?
                 if (checkForUpdates) {
                     this.getLatestVersion().then((latestVersion) => {
-                        if (version && latestVersion && version.compare(latestVersion) < 0) {
-                            log.info(`A new version of Task is available. Current version: v${version}, Latest version: v${latestVersion}`);
-                            vscode.window.showInformationMessage(`A new version of Task is available. Current version: v${version}, Latest version: v${latestVersion}`, "Update").then(this.buttonCallback);
+                        if (this.version && latestVersion && this.version.compare(latestVersion) < 0) {
+                            log.info(`A new version of Task is available. Current version: v${this.version}, Latest version: v${latestVersion}`);
+                            vscode.window.showInformationMessage(`A new version of Task is available. Current version: v${this.version}, Latest version: v${latestVersion}`, "Update").then(this.buttonCallback);
                         }
                         return resolve("ready");
                     }).catch((err) => {
@@ -150,7 +153,16 @@ class TaskfileService {
     public async read(dir: string): Promise<models.Taskfile> {
         log.info(`Searching for taskfile in: "${dir}"`);
         return await new Promise((resolve, reject) => {
-            let command = this.command(`--list-all --json --sort ${settings.treeSort}`);
+            let additionalFlags = "";
+            // Sorting
+            if (settings.treeSort !== "default") {
+                if (this.version && this.version.compare(minimumRequiredVersionForSorting) < 0) {
+                    vscode.window.showWarningMessage(`Task version v${minimumRequiredVersionForSorting} is required to change the sort order. Falling back to "default".`, "Update").then(this.buttonCallback);
+                } else {
+                    additionalFlags = ` --sort ${settings.treeSort}`;
+                }
+            }
+            let command = this.command(`--list-all --json${additionalFlags}`);
             cp.exec(command, { cwd: dir }, (err: cp.ExecException | null, stdout: string) => {
                 if (err) {
                     log.error(err);

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -7,6 +7,7 @@ class Settings {
     public path!: string;
     public checkForUpdates!: boolean;
     public treeNesting!: boolean;
+    public treeSort!: string;
 
     constructor() {
         this.update();
@@ -28,6 +29,7 @@ class Settings {
         this.path = config.get("path") ?? "task";
         this.checkForUpdates = config.get("checkForUpdates") ?? true;
         this.treeNesting = config.get("tree.nesting") ?? true;
+        this.treeSort = config.get("tree.sort") ?? "default";
     }
 }
 


### PR DESCRIPTION
This PR adds a new configuration `tree.sort` for applying a sort to the tree view. The available values are: 

- `default` - The same as `alphanumeric`, but root tasks (with no namespace) will be always appear first.
This is the current sorting behavior
- `none` - No sorting. Tasks will appear in the order they are defined in the taskfile
If multiple taskfiles are used, they will be traversed in lexicographical order of the taskfile path.
- `alphanumeric` - Sorts tasks alphabetically by name ignoring the files they are defined in.

See upstream Task PR: https://github.com/go-task/task/pull/1105