### PR TITLE
feat: improve error handling when taskfiles contain errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Added the ability to sort tasks in the tree view.
+- Improve error handling in when Taskfiles contain errors (#25 by @pd93).
+- Added a new command: `Task: Show Debug Panel` to show the Task debug panel (#25 by @pd93).
+- Added the ability to sort tasks in the tree view (#20 by @pd93).
   - Configurable via `task.tree.sort` setting (values: `"default"` (default), `"alphanumeric"` or `"none"`).
 
 ## v0.1.1 - 2021-03-27

--- a/package.json
+++ b/package.json
@@ -102,6 +102,12 @@
         "title": "Open Usage",
         "category": "Task",
         "icon": "$(globe)"
+      },
+      {
+        "command": "vscode-task.showDebugPanel",
+        "title": "Show Debug Panel",
+        "category": "Task",
+        "icon": "$(debug)"
       }
     ],
     "viewsContainers": {
@@ -124,18 +130,23 @@
     "viewsWelcome": [
       {
         "view": "vscode-task.tasks",
-        "contents": "Task not installed. Click the button below to install it.\n[Install Task](command:vscode-task.openInstallation)\nTo learn more about how to use Task [read our docs](https://taskfile.dev).",
+        "contents": "Task not installed. Click the button below to install it.\n[Install Task](command:vscode-task.openInstallation)\nTo learn more about how to use Task, [read our docs](https://taskfile.dev).",
         "when": "vscode-task:status == 'notInstalled'"
       },
       {
         "view": "vscode-task.tasks",
-        "contents": "Task is out of date. Click the button below to update it.\n[Update Task](command:vscode-task.openInstallation)\nTo learn more about how to use Task [read our docs](https://taskfile.dev).",
+        "contents": "Task is out of date. Click the button below to update it.\n[Update Task](command:vscode-task.openInstallation)\nTo learn more about how to use Task, [read our docs](https://taskfile.dev).",
         "when": "vscode-task:status == 'outOfDate'"
       },
       {
         "view": "vscode-task.tasks",
-        "contents": "No Taskfile found in this workspace. Click the button below to get started and initialize a new Taskfile.\n[Initialize Taskfile](command:vscode-task.init)\nTo learn more about how to use Task [read our docs](https://taskfile.dev).",
+        "contents": "No Taskfile found in this workspace. Click the button below to get started and initialize a new Taskfile.\n[Initialize Taskfile](command:vscode-task.init)\nTo learn more about how to use Task, [read our docs](https://taskfile.dev).",
         "when": "vscode-task:status == 'noTaskfile'"
+      },
+      {
+        "view": "vscode-task.tasks",
+        "contents": "An error occurred while reading the Taskfile. [Check the output panel](command:vscode-task.showDebugPanel) for more information\nTo learn more about how to use Task, [read our docs](https://taskfile.dev).",
+        "when": "vscode-task:status == 'error'"
       }
     ],
     "menus": {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,7 +4,7 @@ class Log {
     private static _instance: Log;
 
     constructor(
-        private _channel: vscode.OutputChannel = vscode.window.createOutputChannel("Task (Debug)")
+        public channel: vscode.OutputChannel = vscode.window.createOutputChannel("Task (Debug)")
     ) { }
 
     public static get instance() {
@@ -13,12 +13,12 @@ class Log {
 
     info(v: any) {
         console.log(v);
-        this._channel.appendLine(v);
+        this.channel.appendLine(v);
     }
 
     error(err: any) {
         console.error(err);
-        this._channel.appendLine(err);
+        this.channel.appendLine(err);
     }
 }
 


### PR DESCRIPTION
When a Taskfile contains error and/or cannot be parsed, we are just showing the "no taskfile" view. This PR will add a new "error" instead and instruct the user to look at the debug output panel for detailed information. The text will be hyperlinked to a new command: `Show Debug Panel` which will open the debug panel automatically.