### PR TITLE
feat: improve watcher performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added the ability to sort tasks in the tree view.
   - Configurable via `task.tree.sort` setting (values: `"default"` (default), `"alphanumeric"` or `"none"`).
+- Added a cancel/timeout to file watcher to improve performance when making lots of file changes (#35 by @pd93).
+  - For example, `git stash pop` of a lot of `.yml` files would cause a huge lag spike as multiple update calls were made.
 
 ## v0.1.1 - 2021-03-27
 


### PR DESCRIPTION
Added a cancel/timeout to file watcher to improve performance when making lots of file changes. For example, calling `git stash pop` on a lot of `.yml` files would cause a huge lag spike as multiple update calls were made. We now cancel old calls as new ones are made and have a 200ms timeout before starting the refresh.

Before:

![image](https://user-images.githubusercontent.com/9294862/234096392-6d1a97de-7693-4326-aff4-f24477e4f33a.png)

After:

![image](https://user-images.githubusercontent.com/9294862/234096063-053230d4-d034-4793-9604-2368b358841a.png)
