### PR TITLE
fix(CommandLineArgs): pass cliArgsInput into runTask

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -128,7 +128,11 @@ export class TaskExtension {
                     prompt: RUNTASKWITHARGS_PROMPT,
                     placeHolder: RUNTASKWITHARGS_PLACEHOLDER
                 }).then((cliArgsInput) => {
-                    services.taskfile.runTask(treeItem.task.name, treeItem.workspace);
+                    if (cliArgsInput === undefined) {
+                        vscode.window.showInformationMessage('No Args Supplied');
+                        return;
+                    }
+                    services.taskfile.runTask(treeItem.task.name, treeItem.workspace, cliArgsInput);
                 });
             }
         }));

--- a/test-workspace/Taskfile.yml
+++ b/test-workspace/Taskfile.yml
@@ -13,6 +13,11 @@ tasks:
     cmds:
       - echo "Hello World"
 
+  hello-with-args:
+    desc: Print custom arguments from Run Task With Args
+    cmds:
+      - echo {{.CLI_ARGS}}
+
   internal-task:
     desc: A task should not be visible in the tree view or executable
     cmds:


### PR DESCRIPTION
Fixing `vscode-task.runTaskWithArgs` after a rebase stopped `cliArgsInput` being passed into `runTask`