### PR TITLE
fix(CommandLineArgs): Not working when terminal is not target

### DIFF
--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -244,7 +244,14 @@ class TaskfileService {
                 log.info(`Running task: "${taskName}" in: "${dir}"`);
 
                 // Spawn a child process
-                let child = cp.spawn(this.command(), [taskName], { cwd: dir });
+                let args = [];
+                if (cliArgs === undefined) {
+                    args = [taskName];
+                } else {
+                    args = [taskName, "--", `${cliArgs}`];
+                }
+
+                let child = cp.spawn(this.command(), args, { cwd: dir });
 
                 // Open the output
                 TaskfileService.outputChannel.clear();


### PR DESCRIPTION
Small miss in the `TaskfileService` led to the command line args passed by the user not being sent to Task if the target was not the Terminal.
