### PR TITLE
add Settings option to always create a new Terminal instance when outputTo=terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,6 +288,11 @@
               "default": "output",
               "description": "Where to print the output of tasks. Note that the output panel does not support ANSI colors."
             },
+            "outputToNewTerminal": {
+              "type": "boolean",
+              "default": false,
+              "description": "When using outputTo=terminal whether to use a new Terminal instance or reuse the last instance."
+            },
             "checkForUpdates": {
               "type": "boolean",
               "default": true,

--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -225,7 +225,7 @@ class TaskfileService {
         if (settings.outputTo === "terminal") {
             log.info(`Running task: "${taskName} ${cliArgs}" in: "${dir}"`);
             var terminal: vscode.Terminal;
-            if (vscode.window.activeTerminal !== undefined) {
+            if (vscode.window.activeTerminal !== undefined && settings.outputToNewTerminal === false) {
                 terminal = vscode.window.activeTerminal;
             } else {
                 terminal = vscode.window.createTerminal("Task");

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -6,6 +6,7 @@ class Settings {
     public updateOn!: string;
     public path!: string;
     public outputTo!: string;
+    public outputToNewTerminal!: boolean;
     public checkForUpdates!: boolean;
     public treeNesting!: boolean;
     public treeSort!: string;
@@ -29,6 +30,7 @@ class Settings {
         this.updateOn = config.get("updateOn") ?? "change";
         this.path = config.get("path") ?? "task";
         this.outputTo = config.get("outputTo") ?? "output";
+        this.outputToNewTerminal = config.get("outputToNewTerminal") ?? false;
         this.checkForUpdates = config.get("checkForUpdates") ?? true;
         this.treeNesting = config.get("tree.nesting") ?? true;
         this.treeSort = config.get("tree.sort") ?? "default";


### PR DESCRIPTION
Hello y'all!
This PR addresses the most basic part of #124 and #125 by adding a Settings option to have `"outputTo": "terminal"` always create a new Terminal instance. Since this requires a bit more work on the user's part to keep from creating a mess of Terminal windows this behavior defaults to **false**, ie: turned off.

I will attempt a second PR that will add the Settings option to create Terminal windows that end their process once the Task has finished (and prompt with the `Press any key to close` VSCode uses)