### PR TITLE
Run the task version command in the workspace root folder

### DIFF
--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -63,8 +63,11 @@ class TaskfileService {
         }
         return await new Promise((resolve) => {
             let command = this.command('--version');
-            cp.exec(command, (_, stdout: string, stderr: string) => {
+            // Determine the root of the working directory of the project
+            let workspaceFolders = vscode.workspace.workspaceFolders;
+            let cwd = workspaceFolders && workspaceFolders.length > 0 ? workspaceFolders[0].uri.fsPath : undefined;
 
+            cp.exec(command, { cwd }, (_, stdout: string, stderr: string) => {
                 // If the version is a devel version, ignore all version checks
                 if (stdout.includes("devel")) {
                     log.info("Using development version of task");


### PR DESCRIPTION
When using asdf to manage the version of task, this allows the `task version` command to execute in a way that will allow the asdf shim to pick the expected version.

Relates to #75, though I don't think it completely solves the problem. I don't have a system using snap to test in.

> Thanks for your pull request, we really appreciate contributions!
>
> Please understand that it may take some time to be reviewed.
>
> Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).
