### PR TITLE
fix: rename configuration key

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "configuration": {
       "title": "Task configuration",
       "properties": {
-        "task": {
+        "taskfile": {
           "type": "object",
           "description": "Task configuration options.",
           "properties": {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -24,7 +24,7 @@ class Settings {
         log.info("Updating settings");
 
         // Get the workspace config
-        let config = vscode.workspace.getConfiguration("task");
+        let config = vscode.workspace.getConfiguration("taskfile");
 
         // Set the properties
         this.updateOn = config.get("updateOn") ?? UpdateOn.save;

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -3,6 +3,7 @@ import { log } from './log.js';
 
 class Settings {
     private static _instance: Settings;
+    private static namespace = "taskfile";
     public updateOn!: UpdateOn;
     public path!: string;
     public outputTo!: OutputTo;
@@ -23,8 +24,18 @@ class Settings {
     public update() {
         log.info("Updating settings");
 
+        // Check if the old configuration still exists
+        let oldConfig = vscode.workspace.getConfiguration("task");
+        if (oldConfig) {
+            vscode.window.showWarningMessage(`Task changed its configuration namespace from "task" to "taskfile". Your task settings will not be applied until you update your settings accordingly.`, "More Info").then(selection => {
+                if (selection === "More Info") {
+                    vscode.env.openExternal(vscode.Uri.parse("https://taskfile.dev/docs/integrations#configuration-namespace-change"));
+                }
+            });
+        }
+
         // Get the workspace config
-        let config = vscode.workspace.getConfiguration("taskfile");
+        let config = vscode.workspace.getConfiguration(Settings.namespace);
 
         // Set the properties
         this.updateOn = config.get("updateOn") ?? UpdateOn.save;


### PR DESCRIPTION
Fixes #56

After considering the response in https://github.com/microsoft/vscode-discussions/discussions/2827, I have made the following changes:

- Renames the Task configuration key from `task` to `taskfile`
- Adds a warning when an old config key is detected

<img width="458" height="138" alt="image" src="https://github.com/user-attachments/assets/8a760325-6274-4ba1-b5c1-4ea1388f1914" />

I've also prepped the follow docs change for the [integrations page on the website](https://taskfile.dev/docs/integrations):

<img width="716" height="416" alt="image" src="https://github.com/user-attachments/assets/5b1859c6-3136-4471-b47a-b9aad4aaae4a" />
