### PR TITLE
fix: add dry option for read operation

### DIFF
--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -182,6 +182,7 @@ class TaskfileService {
         return await new Promise((resolve, reject) => {
             let flags = [
                 "--list-all",
+				"--dry",
                 "--json"
             ];
             // Optional flags


### PR DESCRIPTION
without dry option --list-all updates checksum for sources which ends with task "up to date" even it's not
Fix: https://github.com/go-task/vscode-task/issues/164 and https://github.com/go-task/vscode-task/issues/200

> Thanks for your pull request, we really appreciate contributions!
>
> Please understand that it may take some time to be reviewed.
>
> Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).
