### PR TITLE
feat(tree): sort tasks by Taskfile definition order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.vsix
 .task
 test-workspace/.vscode
+pnpm-workspace.yaml

--- a/src/services/taskfile.ts
+++ b/src/services/taskfile.ts
@@ -1,14 +1,14 @@
 import { Endpoints } from "@octokit/types";
 import * as cp from 'child_process';
 import * as fs from 'fs';
+import { stripVTControlCharacters } from 'node:util';
 import { Octokit } from 'octokit';
 import * as path from 'path';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { Namespace, Task } from '../models/models.js';
-import { OutputTo, TerminalClose, TerminalPer, TreeSort, settings } from '../utils/settings.js';
 import { log } from '../utils/log.js';
-import { stripVTControlCharacters} from 'node:util';
+import { OutputTo, TerminalClose, TerminalPer, TreeSort, settings } from '../utils/settings.js';
 
 const octokit = new Octokit();
 type ReleaseRequest = Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["parameters"];
@@ -132,7 +132,7 @@ class TaskfileService {
             owner: 'go-task',
             repo: 'task'
         };
-        let response: ReleaseResponse = await octokit.rest.repos.getLatestRelease(request);
+        let response = await octokit.rest.repos.getLatestRelease(request);
         return Promise.resolve(semver.parse(response.data.tag_name));
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,
+		"types": ["node", "mocha"]
 	}
 }


### PR DESCRIPTION
## Summary

- When `taskfile.tree.sort` is set to `"default"`, tasks and namespaces in the sidebar are now sorted by their `location.line` property, preserving the original definition order from the Taskfile
- Namespaces are positioned by the smallest line number of their contained tasks, scoped to the parent Taskfile to prevent included files from altering the order
- Minor cleanup: import order in `taskfile.ts`, added `types` to `tsconfig.json`, added `pnpm-workspace.yaml` to `.gitignore`

Closes #230

## Test plan

- [ ] Open a workspace with a Taskfile containing multiple tasks and verify the sidebar displays them in definition order
- [ ] Test with namespaces (included Taskfiles) to verify they appear at the correct position
- [ ] Test with `taskfile.tree.sort` set to `"alphanumeric"` and `"none"` to verify no regression
- [ ] Test with multi-root workspaces
- [ ] Verify the extension compiles and lints without errors (`pnpm compile && pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)