### PR TITLE
feat: integrate with vscode task provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,7 +368,36 @@
           }
         }
       }
-    }
+    },
+    "taskDefinitions": [
+      {
+        "type": "taskfile",
+        "required": [
+          "task"
+        ],
+        "properties": {
+          "task": {
+            "type": "string",
+            "description": "The task to run."
+          },
+          "file": {
+            "type": "string",
+            "description": "The task file to run."
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The workspace folder containing the task file."
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Additional arguments to pass to the task."
+          }
+        }
+      }
+    ]
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ export function activate(context: vscode.ExtensionContext) {
 	let taskExtension: TaskExtension = new TaskExtension();
 
 	// Registration
+	taskExtension.registerTaskProvider(context);
 	taskExtension.registerCommands(context);
 	taskExtension.registerListeners(context);
 

--- a/src/providers/taskProvider.ts
+++ b/src/providers/taskProvider.ts
@@ -1,0 +1,83 @@
+// TODO: Taking inspiration from:
+// - https://code.visualstudio.com/api/extension-guides/task-provider
+// - https://github.com/microsoft/vscode-extension-samples/blob/main/task-provider-sample/src/customTaskProvider.ts
+
+import * as vscode from 'vscode';
+import { Namespace } from '../models/models.js';
+import { settings } from '../utils/settings.js';
+
+export interface TaskDefinition extends vscode.TaskDefinition {
+    task: string;
+    file?: string;
+    workspace?: string;
+    args?: string[];
+}
+
+export class TaskProvider implements vscode.TaskProvider<vscode.Task> {
+    private _taskfiles: Namespace[] = [];
+
+    public setTaskfiles(taskfiles: Namespace[]) {
+        this._taskfiles = taskfiles;
+    }
+
+	public async provideTasks(): Promise<vscode.Task[]> {
+		return this.getTasksFromTaskfiles(this._taskfiles);
+    }
+
+	public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+        const task = _task.definition.task;
+        if (task) {
+            const definition: TaskDefinition = <any>_task.definition;
+            return new vscode.Task(
+                definition,
+                _task.scope ?? vscode.TaskScope.Workspace,
+                definition.task,
+                'taskfile',
+                new vscode.ShellExecution(`task ${definition.task}`)
+            );
+        }
+        return undefined;
+    }
+
+	private getTasksFromTaskfiles(taskfiles: Namespace[]): vscode.Task[] {
+        let tasks: vscode.Task[] = [];
+        taskfiles.forEach(namespace => {
+            tasks = tasks.concat(this.getTasksFromNamespace(namespace));
+        });
+        return tasks;
+	}
+
+    private getTasksFromNamespace(namespace: Namespace): vscode.Task[] {
+        let tasks: vscode.Task[] = [];
+
+        // Add the tasks in this namespace
+        namespace.tasks.forEach(task => {
+            const definition: TaskDefinition = {
+                type: 'taskfile',
+                task: task.name,
+                workspace: namespace.workspace
+            }
+            const uri = vscode.Uri.file(namespace.workspace);
+            const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+            if (!workspaceFolder) {
+                return;
+            }
+            const vscodeTask = new vscode.Task(
+                definition,
+                workspaceFolder,
+                task.name,
+                'taskfile',
+                new vscode.ShellExecution(`${settings.path} ${task.name}`, { cwd: namespace.workspace })
+            );
+            vscodeTask.detail = task.desc || '';
+            tasks.push(vscodeTask);
+        });
+
+        // Recursively handle nested namespaces
+        Array.prototype.forEach.call(namespace.namespaces, (childNamespace: Namespace) => {
+            tasks = tasks.concat(this.getTasksFromNamespace(childNamespace));
+        });
+
+        return tasks;
+    }
+}


### PR DESCRIPTION
Implements vscode's built-in TaskProvider. This will allow you to use the VSCode built-in `Tasks: Run Task` command from the command palette. This currently duplicates our own `Task: Run Task` command, but it will use the nicer temporary panel for the output. We may deprecate the old task run command in the future.

You'll also be able to more easily reference tasks in your `tasks.json` files.

There is plently more work to come with this. Eventually we'd like to always use the official task runner when we run tasks (from sidebar etc), but this will require more work and I figured I may as well release this as its working now.
