### PR TITLE
fix: remove namespaces from task name in nested tree view

### DIFF
--- a/src/providers/taskTreeDataProvider.ts
+++ b/src/providers/taskTreeDataProvider.ts
@@ -88,7 +88,7 @@ export class TaskTreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
             for (const task of tasks) {
                 const definition = new TaskDefinition(task, workspace);
                 treeItems = treeItems.concat(new TaskTreeItem(
-                    task.name != "" ? task.name : this._nesting ? task.task.split(namespaceSeparator).pop() ?? task.task : task.task,
+                    this.getTaskName(task),
                     workspace,
                     definition,
                     vscode.TreeItemCollapsibleState.None,
@@ -102,6 +102,20 @@ export class TaskTreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
         }
 
         return treeItems;
+    }
+
+    getTaskName(task: Task): string {
+        // If the task has a label that's not the task name, return it
+        if (task.name != task.task) {
+            return task.name;
+        }
+
+        // If nesting is enabled, we remove any namespaces from the task name
+        if (this._nesting) {
+            return task.task.split(namespaceSeparator).pop() ?? task.task;
+        }
+
+        return task.task;
     }
 
     getWorkspaces(): WorkspaceTreeItem[] {


### PR DESCRIPTION
Fixes #239.

This was caused by a faulty conditional that was checking is `task.name` was empty and assuming that if it wasn't then the task has a label and should therefore immediately render it.

However, `task.name` is actually _always_ returned. The value is just set to the task name when no label is set. The solution is to check if `task.name` and `task.task` are equal. If not, then use `task.name` (because a label is set). Otherwise, use `task.task` and remove the namespaces if in nested mode.