### PR TITLE
feat: add permissions to actions

### DIFF
--- a/.github/workflows/issue-awaiting-response.yml
+++ b/.github/workflows/issue-awaiting-response.yml
@@ -4,13 +4,16 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+
 jobs:
   issue-awaiting-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -4,13 +4,16 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  issues: write
+
 jobs:
   issue-closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const labels = await github.paginate(
               github.rest.issues.listLabelsOnIssue, {

--- a/.github/workflows/issue-needs-triage.yml
+++ b/.github/workflows/issue-needs-triage.yml
@@ -4,13 +4,16 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   issue-needs-triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const labels = await github.paginate(
               github.rest.issues.listLabelsOnIssue, {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,17 @@ name: Publish
 on:
   push:
     tags:
-      - '*'
+      - "*"
+
+permissions:
+  contents: read
 
 jobs:
   check-versions:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check versions match
         run: |
           echo "package.json version: v$(jq -r .version package.json)"
@@ -19,24 +22,26 @@ jobs:
             echo "package.json version does not match git tag"
             exit 1
           fi
+
   publish-vsce:
     runs-on: ubuntu-latest
     needs: check-versions
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: pnpm install
       - name: Publish
         run: pnpm run publish:vsce
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
   publish-ovsx:
     runs-on: ubuntu-latest
     needs: check-versions
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: pnpm install
       - name: Publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -15,13 +18,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           # cache: "pnpm"


### PR DESCRIPTION
Uses `${{secrets.GITHUB_TOKEN}}` instead of the PAT and adds the `permissions` block to every workflow per best practice.

Also pins workflows to their hashed versions instead of using tags.