### PR TITLE
feat: run tasks in dedicated terminals

### DIFF
--- a/src/models/taskDefinition.ts
+++ b/src/models/taskDefinition.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Location, Task } from './models.js';
 import { settings } from '../utils/settings.js';
+import { useDedicatedTerminal, buildTaskCommand } from '../utils/taskPresentation.js';
 
 export class TaskDefinition implements vscode.TaskDefinition {
     private _task: Task;
@@ -37,17 +38,27 @@ export class TaskDefinition implements vscode.TaskDefinition {
         cliArgs = cliArgs?.filter(x => x !== "") || [];
         const uri = vscode.Uri.file(this.workspace);
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri) || vscode.TaskScope.Workspace;
+        const taskLabel = cliArgs.length > 0 ? `${this.name} ${cliArgs.join(' ')}` : this.name;
+        const definition: vscode.TaskDefinition = {
+            type: this.type,
+            task: this.task,
+            workspace: this.workspace,
+            file: this.location.taskfile
+        };
+        if (cliArgs.length > 0) {
+            definition.args = cliArgs;
+        }
         const task = new vscode.Task(
-            this,
+            definition,
             workspaceFolder,
-            this.name,
+            taskLabel,
             this.type,
             new vscode.ShellExecution(
-                `${settings.path} ${this.task}${cliArgs && cliArgs.length > 0 ? " -- " + cliArgs.join(' ') : ''}`,
+                buildTaskCommand(settings.path, this.task, cliArgs),
                 {cwd: this.workspace}
             )
         );
         task.detail = this.description;
-        return task;
+        return useDedicatedTerminal(task);
     }
 }

--- a/src/providers/taskProvider.ts
+++ b/src/providers/taskProvider.ts
@@ -4,7 +4,8 @@
 
 import * as vscode from 'vscode';
 import { Taskfile } from '../models/taskfile.js';
-import { TaskDefinition } from '../models/taskDefinition.js';
+import { useDedicatedTerminal, buildTaskCommand } from '../utils/taskPresentation.js';
+import { settings } from '../utils/settings.js';
 
 export class TaskProvider implements vscode.TaskProvider<vscode.Task> {
     private _taskfiles: Taskfile[] = [];
@@ -22,16 +23,24 @@ export class TaskProvider implements vscode.TaskProvider<vscode.Task> {
     }
 
 	public resolveTask(_task: vscode.Task): vscode.Task | undefined {
-        const task = _task.definition.task;
-        if (task) {
-            const definition: TaskDefinition = <any>_task.definition;
-            return new vscode.Task(
+        const taskName = _task.definition.task;
+        if (taskName) {
+            const definition = _task.definition;
+            const cliArgs = Array.isArray(definition.args)
+                ? definition.args.filter((arg: unknown): arg is string => typeof arg === 'string' && arg !== "")
+                : [];
+            const workspace = typeof definition.workspace === 'string' ? definition.workspace : undefined;
+            const executionOptions = workspace ? {cwd: workspace} : undefined;
+            return useDedicatedTerminal(new vscode.Task(
                 definition,
                 _task.scope ?? vscode.TaskScope.Workspace,
-                definition.task,
+                taskName,
                 'taskfile',
-                new vscode.ShellExecution(`task ${definition.task}`)
-            );
+                new vscode.ShellExecution(
+                    buildTaskCommand(settings.path, taskName, cliArgs),
+                    executionOptions
+                )
+            ), _task.presentationOptions);
         }
         return undefined;
     }

--- a/src/utils/taskPresentation.ts
+++ b/src/utils/taskPresentation.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+const dedicatedTerminalDefaults: vscode.TaskPresentationOptions = {
+    panel: vscode.TaskPanelKind.Dedicated,
+    reveal: vscode.TaskRevealKind.Always,
+    clear: false,
+    showReuseMessage: false
+};
+
+// Applies our dedicated-terminal presentation defaults, while letting any
+// user-supplied options (e.g. from tasks.json) take precedence.
+export function useDedicatedTerminal(task: vscode.Task, overrides?: vscode.TaskPresentationOptions): vscode.Task {
+    task.presentationOptions = { ...dedicatedTerminalDefaults, ...overrides };
+    return task;
+}
+
+export function buildTaskCommand(taskBin: string, taskName: string, cliArgs: string[]): string {
+    return `${taskBin} ${taskName}${cliArgs.length > 0 ? " -- " + cliArgs.join(' ') : ''}`;
+}


### PR DESCRIPTION
I was tired of VS code not launching my test task in a separate terminal while a debug task was running. So I made this PR and fork.

Another problem was that when a task is running VS Code would pop up a "select instance to terminate" dialog. Then it would run the wrong task somehow.

The change itself was done by Codex, then Claude reviewed the changes and provided the following CL description...

Route both provider-generated tasks (toTask) and tasks resolved from tasks.json (resolveTask) through a shared useDedicatedTerminal helper so each task gets its own panel, while letting user-defined presentation options in tasks.json take precedence.

Also fixes resolveTask, which previously hardcoded `task <name>` and ran with no cwd: it now honors the configured task binary path, sets the workspace as cwd, and forwards CLI args. Command-string construction is shared via buildTaskCommand to keep the two paths in sync.
